### PR TITLE
Change visibility of JBehaveUtils to public

### DIFF
--- a/src/main/java/com/epam/reportportal/jbehave/JBehaveUtils.java
+++ b/src/main/java/com/epam/reportportal/jbehave/JBehaveUtils.java
@@ -47,7 +47,7 @@ import static rp.com.google.common.base.Throwables.getStackTraceAsString;
  *
  * @author Andrei Varabyeu
  */
-class JBehaveUtils {
+public class JBehaveUtils {
 
 	private JBehaveUtils() {
 		// static utilities class


### PR DESCRIPTION
Visibility of JBehaveUtils has changed to public to be able to reuse its functionality like overriding of com.epam.reportportal.jbehave.ReportPortalStoryReporter.pending(String) method in case when we want to make some operations on a Step object like setting of issue status before it's finished

Issue: we use custom mapping between test statuses and RP defect type, the mapping includes value for pending step status as well, currently we are not able to set issue type because logic inside pending method starts and immediately finished the step.